### PR TITLE
Minor Readme update - guard init command for just teabag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ rails generate teabag:install
 Generate the Guardfile that includes the standard Guard-Teabag template.
 
 ```
-bundle exec guard init
+bundle exec guard init teabag
 ```
 
 


### PR DESCRIPTION
Running `bundle exec guard init` will re-init all your guard templates which is not ideal.
`bundle exec guard init teabag` would init just teabag.
