### PR TITLE
Fix Guardfile template Regex to be more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The default Guardfile will watch for any file changes within your `app/assets/ja
 Guardfile
 ```ruby
 guard :teaspoon do
-  watch(%r{app/assets/javascripts/(.+).js}) { |m| "#{m[1]}_spec" }
-  watch(%r{/spec/javascripts/(.*)})
+  watch(%r{^app/assets/javascripts/(.+).js}) { |m| "#{m[1]}_spec" }
+  watch(%r{^/spec/javascripts/(.*)})
 end
 ```
 

--- a/lib/guard/teaspoon/templates/Guardfile
+++ b/lib/guard/teaspoon/templates/Guardfile
@@ -1,7 +1,7 @@
 guard :teaspoon do
   # Implementation files
-  watch(%r{app/assets/javascripts/(.+).js}) { |m| "#{m[1]}_spec" }
+  watch(%r{^app/assets/javascripts/(.+).js}) { |m| "#{m[1]}_spec" }
 
   # Specs / Helpers
-  watch(%r{spec/javascripts/(.*)})
+  watch(%r{^spec/javascripts/(.*)})
 end


### PR DESCRIPTION
Was causing #8 (tests running twice) for me most likely because of an overly
zealous regex search that was seeing asset pipeline artifacts after changes
were made.
