### PR TITLE
Flatten paths in case a directory is given

### DIFF
--- a/lib/guard/teaspoon/resolver.rb
+++ b/lib/guard/teaspoon/resolver.rb
@@ -15,6 +15,7 @@ module Guard
           if result = ::Teaspoon::Suite.resolve_spec_for(path)
             suite = @suites[result[:suite]] ||= []
             suite << result[:path]
+            @suites[result[:suite]] = suite.flatten
           end
         end
       end

--- a/spec/guard/teaspoon/resolver_spec.rb
+++ b/spec/guard/teaspoon/resolver_spec.rb
@@ -23,6 +23,13 @@ describe Guard::Teaspoon::Resolver do
       expect(subject.suites).to eq({"default" => ["foo", "bar"], "other" => ["baz"]})
     end
 
+    it "resolves directories" do
+      paths = ["spec/javascripts/my_test_spec.js", "spec/javascripts/my_other_test_spec.js"]
+      Teaspoon::Suite.stub(:resolve_spec_for).and_return(suite: 'default', path: paths)
+      subject.resolve([ 'spec/javascripts' ])
+      expect(subject.suites).to eq({"default" => paths})
+    end
+
   end
 
 end

--- a/spec/guard/teaspoon/runner_spec.rb
+++ b/spec/guard/teaspoon/runner_spec.rb
@@ -27,7 +27,7 @@ describe Guard::Teaspoon::Runner do
 
   describe "#run_all" do
 
-    let(:console) { mock(execute: nil) }
+    let(:console) { double(execute: nil) }
 
     before do
       subject.console = console
@@ -43,7 +43,7 @@ describe Guard::Teaspoon::Runner do
 
   describe "#run" do
 
-    let(:console) { mock(execute: nil) }
+    let(:console) { double(execute: nil) }
 
     before do
       subject.console = console

--- a/spec/guard/teaspoon_spec.rb
+++ b/spec/guard/teaspoon_spec.rb
@@ -67,7 +67,7 @@ describe Guard::Teaspoon do
 
   describe "#run_all" do
 
-    let(:runner) { mock(run_all: nil) }
+    let(:runner) { double(run_all: nil) }
 
     before do
       subject.runner = runner


### PR DESCRIPTION
This will allow directories to passed in the guard file.

Like so:

``` ruby
watch(%r{test/javascripts/.+_helper\.(js|coffee|js\.coffee)}) { 'test/javascripts' }
```

Otherwise it will throw this error "TypeError: no implicit conversion of Array into String".

Also, `mock` has been deprecated in favor of `double` so I went ahead and made those changes.
