### PR TITLE
Fix example Guardfile in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Guardfile
 ```ruby
 guard :teaspoon do
   watch(%r{^app/assets/javascripts/(.+).js}) { |m| "#{m[1]}_spec" }
-  watch(%r{^/spec/javascripts/(.*)})
+  watch(%r{^spec/javascripts/(.*)})
 end
 ```
 


### PR DESCRIPTION
Well hello there, Mr. Jackson.

I know it's only a sample, but if Teaspoon's default is to create `spec/javascripts`, the regex in that example `Guardfile` doesn't work so hot with the leading slash.
