### PR TITLE
Make guard run_all after previously failing tests pass

### DIFF
--- a/lib/guard/teaspoon.rb
+++ b/lib/guard/teaspoon.rb
@@ -31,12 +31,14 @@ module Guard
     end
 
     def run_all
-      passed = @runner.run_all(@options[:run_all])
+      failed = @runner.run_all(@options[:run_all])
 
-      unless @last_failed = !passed
-        @failed_paths = []
-      else
+      if failed
+        @last_failed = true
         throw :task_has_failed
+      else
+        @last_failed = false
+        true
       end
     end
 
@@ -56,8 +58,10 @@ module Guard
       if failed
         @last_failed = true
         Notifier.notify("Failed", title: "Teaspoon Guard", image: :failed)
+        throw :task_has_failed
       else
         Notifier.notify("Success", title: "Teaspoon Guard", image: :success)
+        run_all if @last_failed
       end
 
       #original_paths = paths.dup


### PR DESCRIPTION
This is related to the changes in https://github.com/modeset/teaspoon/pull/173 and helps to fix https://github.com/modeset/guard-teaspoon/issues/3.

I should also note that this problem was more than just not running all tests on success. This also fixes the problem that guard-teaspoon could not re-run all tests after it had run tests on a modified file because that file would keep being re-run instead.
