### PR TITLE
Show filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ end
 
 ### Available Options
 
-...document when this is better hammered out...
+```ruby
+focus_on_failed: true     # Focus on the first 10 failed specs first, rerun till they pass, default: false
+all_after_pass: true      # Run all tests after changed tests pass, default: true
+all_on_start: true        # Run all the tests at startup, default: true
+keep_failed: true         # Keep failed tests until they pass, default: true
+show_filenames: true      # Show the names of files that are being run, default: true
+```
 
 
 ## License
@@ -104,4 +110,3 @@ Copyright 2014 [Mode Set](https://github.com/modeset)
 
 ## Make Code Not War
 ![crest](https://secure.gravatar.com/avatar/aa8ea677b07f626479fd280049b0e19f?s=75)
-

--- a/lib/guard/teaspoon.rb
+++ b/lib/guard/teaspoon.rb
@@ -17,7 +17,7 @@ module Guard
         formatters:           'clean',
         run_all:              {},
         run_on_modifications: {},
-        show_modified_files:  true
+        show_filenames:       true
       }.merge(options)
     end
 

--- a/lib/guard/teaspoon.rb
+++ b/lib/guard/teaspoon.rb
@@ -16,7 +16,8 @@ module Guard
         keep_failed:          true,
         formatters:           'clean',
         run_all:              {},
-        run_on_modifications: {}
+        run_on_modifications: {},
+        show_modified_files:  true
       }.merge(options)
     end
 

--- a/lib/guard/teaspoon.rb
+++ b/lib/guard/teaspoon.rb
@@ -24,7 +24,7 @@ module Guard
       reload
       @resolver = Resolver.new(@options)
       @runner = Runner.new(@options)
-      UI.info "Guard::Teaspoon is running"
+      Compat::UI.info "Guard::Teaspoon is running"
       run_all if @options[:all_on_start]
     end
 

--- a/lib/guard/teaspoon/runner.rb
+++ b/lib/guard/teaspoon/runner.rb
@@ -23,6 +23,7 @@ module Guard
 
       def run(files = [], options = {})
         return false if files.empty?
+        Compat::UI.info "Running files: " + files.join(', ')
         @console.execute(@options.merge(options).merge(files: files))
       end
 

--- a/lib/guard/teaspoon/runner.rb
+++ b/lib/guard/teaspoon/runner.rb
@@ -18,8 +18,6 @@ module Guard
       end
 
       def run_all(options = {})
-        # run all tests instead of running only the last run tests
-        @options.delete :files
         @console.execute(@options.merge(options))
       end
 

--- a/lib/guard/teaspoon/runner.rb
+++ b/lib/guard/teaspoon/runner.rb
@@ -24,7 +24,7 @@ module Guard
       def run(files = [], options = {})
         return false if files.empty?
         run_options = @options.merge(options).merge(files: files)
-        Compat::UI.info "Running files: " + files.join(', ') if run_options[:show_modified_files]
+        Compat::UI.info "Running files: " + files.join(', ') if run_options[:show_filenames]
         @console.execute(run_options)
       end
 

--- a/lib/guard/teaspoon/runner.rb
+++ b/lib/guard/teaspoon/runner.rb
@@ -23,8 +23,9 @@ module Guard
 
       def run(files = [], options = {})
         return false if files.empty?
-        Compat::UI.info "Running files: " + files.join(', ')
-        @console.execute(@options.merge(options).merge(files: files))
+        run_options = @options.merge(options).merge(files: files)
+        Compat::UI.info "Running files: " + files.join(', ') if run_options[:show_modified_files]
+        @console.execute(run_options)
       end
 
       private

--- a/spec/guard/teaspoon/runner_spec.rb
+++ b/spec/guard/teaspoon/runner_spec.rb
@@ -61,10 +61,16 @@ describe Guard::Teaspoon::Runner do
       subject.run([], baz: "teaspoon")
     end
 
-    it 'logs the files that are being run' do
+    it 'shows modified files when the show_modified_files is set' do
       files = ["file1", "file2"]
       expect(Guard::Compat::UI).to receive(:info).with("Running files: file1, file2")
-      subject.run(files, baz: "teaspoon")
+      subject.run(files, show_modified_files: true)
+    end
+
+    it 'does not show modified files when the show_modified_files is set to false' do
+      files = ["file1", "file2"]
+      expect(Guard::Compat::UI).not_to receive(:info)
+      subject.run(files, show_modified_files: false)
     end
 
   end

--- a/spec/guard/teaspoon/runner_spec.rb
+++ b/spec/guard/teaspoon/runner_spec.rb
@@ -61,16 +61,16 @@ describe Guard::Teaspoon::Runner do
       subject.run([], baz: "teaspoon")
     end
 
-    it 'shows modified files when the show_modified_files is set' do
+    it 'shows filenames when the show_filenames flag is set' do
       files = ["file1", "file2"]
       expect(Guard::Compat::UI).to receive(:info).with("Running files: file1, file2")
-      subject.run(files, show_modified_files: true)
+      subject.run(files, show_filenames: true)
     end
 
-    it 'does not show modified files when the show_modified_files is set to false' do
+    it 'does not show filenames when the show_filenames flag is set to false' do
       files = ["file1", "file2"]
       expect(Guard::Compat::UI).not_to receive(:info)
-      subject.run(files, show_modified_files: false)
+      subject.run(files, show_filenames: false)
     end
 
   end

--- a/spec/guard/teaspoon/runner_spec.rb
+++ b/spec/guard/teaspoon/runner_spec.rb
@@ -61,6 +61,12 @@ describe Guard::Teaspoon::Runner do
       subject.run([], baz: "teaspoon")
     end
 
+    it 'logs the files that are being run' do
+      files = ["file1", "file2"]
+      expect(Guard::Compat::UI).to receive(:info).with("Running files: file1, file2")
+      subject.run(files, baz: "teaspoon")
+    end
+
   end
 
 end

--- a/spec/guard/teaspoon/runner_spec.rb
+++ b/spec/guard/teaspoon/runner_spec.rb
@@ -39,13 +39,6 @@ describe Guard::Teaspoon::Runner do
       subject.run_all(baz: "teaspoon")
     end
 
-    it 'removes previously set files so that all files are run' do
-      subject = Guard::Teaspoon::Runner.new(files: ["file1", "file2"], baz: "teaspoon")
-      subject.console = console
-      console.should_receive(:execute).with(foo: "bar", baz: "teaspoon")
-      subject.run_all(foo: "bar")
-    end
-
   end
 
   describe "#run" do

--- a/spec/guard/teaspoon_spec.rb
+++ b/spec/guard/teaspoon_spec.rb
@@ -22,7 +22,7 @@ describe Guard::Teaspoon do
         formatters:           'clean',
         run_all:              {},
         run_on_modifications: {},
-        show_modified_files:  true,
+        show_filenames:       true,
         other_option:         'foo'
       })
     end

--- a/spec/guard/teaspoon_spec.rb
+++ b/spec/guard/teaspoon_spec.rb
@@ -8,6 +8,7 @@ describe Guard::Teaspoon do
   before do
     Guard::Teaspoon::Resolver.stub(:new)
     Guard::Teaspoon::Runner.stub(:new)
+    Guard::Compat::UI.stub(:notify)
   end
 
   describe "#initialize" do

--- a/spec/guard/teaspoon_spec.rb
+++ b/spec/guard/teaspoon_spec.rb
@@ -8,7 +8,6 @@ describe Guard::Teaspoon do
   before do
     Guard::Teaspoon::Resolver.stub(:new)
     Guard::Teaspoon::Runner.stub(:new)
-    Guard::Compat::UI.stub(:notify)
   end
 
   describe "#initialize" do
@@ -31,7 +30,6 @@ describe Guard::Teaspoon do
   describe "#start" do
     before do
       subject.stub(:run_all)
-      Guard::UI.stub(:info)
     end
 
     it "calls reload" do
@@ -46,7 +44,7 @@ describe Guard::Teaspoon do
     end
 
     it "logs that we're starting" do
-      Guard::UI.should_receive(:info).with("Guard::Teaspoon is running")
+      Guard::Compat::UI.should_receive(:info).with("Guard::Teaspoon is running")
       subject.start
     end
 

--- a/spec/guard/teaspoon_spec.rb
+++ b/spec/guard/teaspoon_spec.rb
@@ -22,6 +22,7 @@ describe Guard::Teaspoon do
         formatters:           'clean',
         run_all:              {},
         run_on_modifications: {},
+        show_modified_files:  true,
         other_option:         'foo'
       })
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,4 +18,10 @@ Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }
 RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
+
+  config.before(:each) do
+    Guard::Compat::UI.stub(:notify)
+    Guard::Compat::UI.stub(:info)
+    Guard::Compat::UI.stub(:error)
+  end    
 end


### PR DESCRIPTION
In this pull request I removed the 'run all files' fix from my previous pull request as the issue has already been resolved in the Teaspoon 0.9.0 gem release (I was running 0.8.0 for some reason).

In addition I show the files that are being run with the Runner#run method. This functionality is enabled by default and can be switched off by setting the show_filenames option to false (also see README.md).

Finally I add some more Guard::Compat fixes.

My attempts to fix the feature spec were to no avail, alas. I fixed the Rails 4 issue, but the file change would still go undetected by guard.

These were my changes:

``` diff
diff --git a/spec/features/guard_teaspoon_spec.rb b/spec/features/guard_teaspoon_spec.rb
index 4dadefe..0357292 100644
--- a/spec/features/guard_teaspoon_spec.rb
+++ b/spec/features/guard_teaspoon_spec.rb
@@ -9,6 +9,9 @@ feature "Full setup of an app that can run guard-teaspoon", aruba: true do
     append_to_file("Gemfile", "gem 'teaspoon'" + "\n")
     append_to_file("Gemfile", "gem 'guard-teaspoon', path: '#{File.expand_path('../../../', __FILE__)}'" + "\n")
     append_to_file("Gemfile", "gem 'rb-fsevent'" + "\n")
+    append_to_file 'config/initializers/assets.rb',
+                   'Rails.application.config.assets.precompile += %w( ' \
+                   'teaspoon.css teaspoon-teaspoon.js jasmine/1.3.1.js teaspoon-jasmine.js )' + "\n"
     run_simple("bundle install --local")
   end

@@ -46,7 +49,7 @@ feature "Full setup of an app that can run guard-teaspoon", aruba: true do
     assert_partial_output("Teaspoon running default suite at", all_output)

     # when the file has been modified
-    assert_partial_output("/teaspoon/default?file[]=", all_output)
+    assert_partial_output("/teaspoon/default", all_output)
     assert_partial_output("tmp/aruba/testapp/spec/javascripts/test_spec.js", all_output)
   end
 end
```
