### PR TITLE
Rescue exceptions from Guard::Teaspoon::Runner.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "teaspoon", github: "modeset/teaspoon"
+gem "teaspoon-jasmine", github: "modeset/teaspoon"
 
 # used by the dummy application
 gem "rails", ">= 4.0.0"

--- a/lib/guard/teaspoon.rb
+++ b/lib/guard/teaspoon.rb
@@ -68,7 +68,7 @@ module Guard
     private
 
     def notify(status)
-      UI.info(status.to_s.capitalize, title: "Teaspoon Guard", image: status)
+      Notifier.notify(status.to_s.capitalize, title: "Teaspoon Guard", image: status)
     end
 
     def remove_failed(paths)

--- a/lib/guard/teaspoon/runner.rb
+++ b/lib/guard/teaspoon/runner.rb
@@ -21,11 +21,15 @@ module Guard
         # run all tests instead of running only the last run tests
         @options.delete :files
         @console.execute(@options.merge(options))
+      rescue
+        false # don't bubble up exceptions
       end
 
       def run(files = [], options = {})
         return false if files.empty?
         @console.execute(@options.merge(options).merge(files: files))
+      rescue
+        false # don't bubble up exceptions
       end
 
       private

--- a/lib/guard/teaspoon/version.rb
+++ b/lib/guard/teaspoon/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module TeaspoonVersion
-    VERSION = "0.8.0"
+    VERSION = "0.8.1"
   end
 end

--- a/lib/guard/teaspoon/version.rb
+++ b/lib/guard/teaspoon/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module TeaspoonVersion
-    VERSION = "0.8.1"
+    VERSION = "0.8.2"
   end
 end

--- a/spec/features/guard_teaspoon_spec.rb
+++ b/spec/features/guard_teaspoon_spec.rb
@@ -7,6 +7,7 @@ feature "Full setup of an app that can run guard-teaspoon", aruba: true do
     run_simple("bundle exec rails new testapp --skip-bundle")
     cd("testapp")
     append_to_file("Gemfile", "gem 'teaspoon'" + "\n")
+    append_to_file("Gemfile", "gem 'teaspoon-jasmine'" + "\n")
     append_to_file("Gemfile", "gem 'guard-teaspoon', path: '#{File.expand_path('../../../', __FILE__)}'" + "\n")
     append_to_file("Gemfile", "gem 'rb-fsevent'" + "\n")
     run_simple("bundle install")

--- a/spec/guard/teaspoon/resolver_spec.rb
+++ b/spec/guard/teaspoon/resolver_spec.rb
@@ -16,16 +16,16 @@ describe Guard::Teaspoon::Resolver do
   describe "#resolve" do
 
     it "calls through to Teaspoon::Suite to resolve paths and assigns them to suites" do
-      Teaspoon::Suite.should_receive(:resolve_spec_for).with("foo").and_return(suite: "default", path: "foo")
-      Teaspoon::Suite.should_receive(:resolve_spec_for).with("bar").and_return(suite: "default", path: "bar")
-      Teaspoon::Suite.should_receive(:resolve_spec_for).with("baz").and_return(suite: "other", path: "baz")
+      expect(Teaspoon::Suite).to receive(:resolve_spec_for).with("foo").and_return(suite: "default", path: "foo")
+      expect(Teaspoon::Suite).to receive(:resolve_spec_for).with("bar").and_return(suite: "default", path: "bar")
+      expect(Teaspoon::Suite).to receive(:resolve_spec_for).with("baz").and_return(suite: "other", path: "baz")
       subject.resolve(["foo", "bar", "baz"])
       expect(subject.suites).to eq({"default" => ["foo", "bar"], "other" => ["baz"]})
     end
 
     it "resolves directories" do
       paths = ["spec/javascripts/my_test_spec.js", "spec/javascripts/my_other_test_spec.js"]
-      Teaspoon::Suite.stub(:resolve_spec_for).and_return(suite: 'default', path: paths)
+      expect(Teaspoon::Suite).to receive(:resolve_spec_for).and_return(suite: 'default', path: paths)
       subject.resolve([ 'spec/javascripts' ])
       expect(subject.suites).to eq({"default" => paths})
     end

--- a/spec/guard/teaspoon/runner_spec.rb
+++ b/spec/guard/teaspoon/runner_spec.rb
@@ -4,7 +4,7 @@ require "teaspoon/console"
 describe Guard::Teaspoon::Runner do
 
   before do
-    Teaspoon::Console.stub(:new)
+    allow(Teaspoon::Console).to receive(:new)
   end
 
   describe "#initialize" do
@@ -16,10 +16,10 @@ describe Guard::Teaspoon::Runner do
     end
 
     it "aborts with a message on Teaspoon::EnvironmentNotFound" do
-      Teaspoon::Console.should_receive(:new).and_raise(Teaspoon::EnvironmentNotFound)
-      Guard::Teaspoon::Runner.any_instance.should_receive(:abort)
-      STDOUT.should_receive(:print).with("Unable to load Teaspoon environment in {spec/teaspoon_env.rb, test/teaspoon_env.rb, teaspoon_env.rb}.\n")
-      STDOUT.should_receive(:print).with("Consider using -r path/to/teaspoon_env\n")
+      allow(Teaspoon::Console).to receive(:new) { raise Teaspoon::EnvironmentNotFound, {} }
+      expect_any_instance_of(Guard::Teaspoon::Runner).to receive(:abort)
+      expect(STDOUT).to receive(:print).with("Unable to load Teaspoon environment in {spec/teaspoon_env.rb, test/teaspoon_env.rb, teaspoon_env.rb}.\n")
+      expect(STDOUT).to receive(:print).with("Consider using -r path/to/teaspoon_env\n")
       Guard::Teaspoon::Runner.new
     end
 
@@ -35,14 +35,14 @@ describe Guard::Teaspoon::Runner do
     end
 
     it "calls execute on console" do
-      console.should_receive(:execute).with({foo: "bar", baz: "teaspoon"})
+      expect(console).to receive(:execute).with({foo: "bar", baz: "teaspoon"})
       subject.run_all(baz: "teaspoon")
     end
 
     it 'removes previously set files so that all files are run' do
       subject = Guard::Teaspoon::Runner.new(files: ["file1", "file2"], baz: "teaspoon")
       subject.console = console
-      console.should_receive(:execute).with(foo: "bar", baz: "teaspoon")
+      expect(console).to receive(:execute).with(foo: "bar", baz: "teaspoon")
       subject.run_all(foo: "bar")
     end
 
@@ -59,12 +59,12 @@ describe Guard::Teaspoon::Runner do
 
     it "calls execute on console" do
       files = ["file1", "file2"]
-      console.should_receive(:execute).with({foo: "bar", baz: "teaspoon", files: files})
+      expect(console).to receive(:execute).with({foo: "bar", baz: "teaspoon", files: files})
       subject.run(files, baz: "teaspoon")
     end
 
     it "does nothing if there's no paths" do
-      console.should_not_receive(:execute)
+      expect(console).to_not receive(:execute)
       subject.run([], baz: "teaspoon")
     end
 

--- a/spec/guard/teaspoon_spec.rb
+++ b/spec/guard/teaspoon_spec.rb
@@ -6,8 +6,8 @@ describe Guard::Teaspoon do
   subject { Guard::Teaspoon.new({}) }
 
   before do
-    Guard::Teaspoon::Resolver.stub(:new)
-    Guard::Teaspoon::Runner.stub(:new)
+    allow(Guard::Teaspoon::Resolver).to receive(:new)
+    allow(Guard::Teaspoon::Runner).to receive(:new)
   end
 
   describe "#initialize" do
@@ -29,34 +29,34 @@ describe Guard::Teaspoon do
 
   describe "#start" do
     before do
-      subject.stub(:run_all)
-      Guard::UI.stub(:info)
+      allow(subject).to receive(:run_all)
+      allow(Guard::UI).to receive(:info)
     end
 
     it "calls reload" do
-      Guard::Teaspoon.any_instance.should_receive(:reload)
+      expect_any_instance_of(Guard::Teaspoon).to receive(:reload)
       subject.start
     end
 
     it "creates a resolver, and a runner" do
-      Guard::Teaspoon::Resolver.should_receive(:new)
-      Guard::Teaspoon::Runner.should_receive(:new)
+      expect(Guard::Teaspoon::Resolver).to receive(:new)
+      expect(Guard::Teaspoon::Runner).to receive(:new)
       subject.start
     end
 
     it "logs that we're starting" do
-      Guard::UI.should_receive(:info).with("Guard::Teaspoon is running")
+      expect(Guard::UI).to receive(:info).with("Guard::Teaspoon is running")
       subject.start
     end
 
     it "calls #run_all if we're supposed to" do
-      subject.should_receive(:run_all)
+      expect(subject).to receive(:run_all)
       subject.start
     end
 
     it "doesn't run all if we're not supposed to" do
       subject.instance_variable_set(:@options, {all_on_start: false})
-      subject.should_not_receive(:run_all)
+      expect(subject).to_not receive(:run_all)
       subject.start
     end
 
@@ -70,19 +70,19 @@ describe Guard::Teaspoon do
     end
 
     it "calls #run_all on the runner" do
-      runner.should_receive(:run_all).and_return(true)
+      expect(runner).to receive(:run_all).and_return(true)
       subject.run_all
     end
 
     it "resets failed_paths if all tests passed" do
       subject.failed_paths = ["1", "2"]
-      runner.should_receive(:run_all).and_return(true)
+      expect(runner).to receive(:run_all).and_return(true)
       subject.run_all
       expect(subject.failed_paths).to eq([])
     end
 
     it "throws :task_has_failed if the tests didn't pass" do
-      runner.should_receive(:run_all).and_return(false)
+      expect(runner).to receive(:run_all).and_return(false)
       expect { subject.run_all }.to raise_error(ArgumentError)
     end
 
@@ -113,8 +113,8 @@ describe Guard::Teaspoon do
     it "does nothing if the spec paths cant be resolved" do
       subject.last_failed = false
 
-      resolver.should_receive(:resolve).with(original_paths)
-      resolver.should_receive(:suites).and_return([])
+      expect(resolver).to receive(:resolve).with(original_paths)
+      expect(resolver).to receive(:suites).and_return([])
 
       subject.run_on_modifications(original_paths)
     end
@@ -122,11 +122,11 @@ describe Guard::Teaspoon do
     it "runs every suite that is resolved to a spec" do
       subject.last_failed = false
 
-      resolver.should_receive(:resolve).with(original_paths)
-      resolver.should_receive(:suites).and_return({"default" => ["foo", "bar"], "another_suite" => ["a_spec"]})
+      expect(resolver).to receive(:resolve).with(original_paths)
+      expect(resolver).to receive(:suites).and_return({"default" => ["foo", "bar"], "another_suite" => ["a_spec"]})
 
-      runner.should_receive(:run).with(["foo", "bar"], {suite: "default"}).and_return(true)
-      runner.should_receive(:run).with(["a_spec"], {suite: "another_suite"}).and_return(true)
+      expect(runner).to receive(:run).with(["foo", "bar"], {suite: "default"}).and_return(true)
+      expect(runner).to receive(:run).with(["a_spec"], {suite: "another_suite"}).and_return(true)
 
       subject.run_on_modifications(original_paths)
     end
@@ -134,10 +134,10 @@ describe Guard::Teaspoon do
     it "sets last_failed to false and throws :task_has_failed if a spec fails" do
       subject.last_failed = false
 
-      resolver.should_receive(:resolve)
-      resolver.should_receive(:suites).and_return({"default" => ["foo", "bar"]})
+      expect(resolver).to receive(:resolve)
+      expect(resolver).to receive(:suites).and_return({"default" => ["foo", "bar"]})
 
-      runner.should_receive(:run).and_return(false)
+      expect(runner).to receive(:run).and_return(false)
 
       expect { subject.run_on_modifications(original_paths) }.to throw_symbol(:task_has_failed)
       expect(subject.last_failed).to eq(true)
@@ -146,11 +146,11 @@ describe Guard::Teaspoon do
     it "if all specs pass, it calls run_all if the previous run was unsuccessful" do
       subject.last_failed = true
 
-      resolver.should_receive(:resolve)
-      resolver.should_receive(:suites).and_return({"default" => ["foo", "bar"]})
+      expect(resolver).to receive(:resolve)
+      expect(resolver).to receive(:suites).and_return({"default" => ["foo", "bar"]})
 
-      runner.should_receive(:run).and_return(true)
-      runner.should_receive(:run_all).and_return(true)
+      expect(runner).to receive(:run).and_return(true)
+      expect(runner).to receive(:run_all).and_return(true)
 
       subject.run_on_modifications(original_paths)
     end


### PR DESCRIPTION
This will prevent bad specs from crashing Guard and giving errors like this:

16:50:31 - ERROR - Guard::Teaspoon failed to achieve its <start>
16:50:31 - INFO - Guard::Teaspoon has just been fired