### PR TITLE
Fix `all_after_pass` option

### DIFF
--- a/lib/guard/teaspoon.rb
+++ b/lib/guard/teaspoon.rb
@@ -61,7 +61,7 @@ module Guard
         throw :task_has_failed
       else
         notify(:success)
-        run_all if @last_failed
+        run_all if @last_failed && @options[:all_after_pass]
       end
     end
 

--- a/spec/guard/teaspoon_spec.rb
+++ b/spec/guard/teaspoon_spec.rb
@@ -155,6 +155,20 @@ describe Guard::Teaspoon do
       subject.run_on_modifications(original_paths)
     end
 
+    it "if all specs pass, it does not call run_all if the option all_after_pass is set to false" do
+      options = subject.instance_variable_get(:@options)
+      subject.instance_variable_set(:@options, options.merge({ all_after_pass: false }))
+      subject.last_failed = true
+
+      expect(resolver).to receive(:resolve)
+      expect(resolver).to receive(:suites).and_return({"default" => ["foo", "bar"]})
+
+      expect(runner).to receive(:run).and_return(true)
+      expect(runner).to_not receive(:run_all)
+
+      subject.run_on_modifications(original_paths)
+    end
+
   end
 
 end


### PR DESCRIPTION
Guard was running all after pass even when the option was set to false. 
The default is still true. 
